### PR TITLE
missing single quote

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vestaboard/vbml",
-  "version": "1.2.16",
+  "version": "1.2.17",
   "description": "The Vestaboard markup language",
   "main": "lib/index.js",
   "scripts": {

--- a/src/classic.ts
+++ b/src/classic.ts
@@ -172,6 +172,7 @@ const VestaboardCharactersCodeMap = {
   "´": VestaboardCharacter.SingleQuote,
   "ˋ": VestaboardCharacter.SingleQuote,
   "ˊ": VestaboardCharacter.SingleQuote,
+  "‚":VestaboardCharacter.SingleQuote,
   "`": VestaboardCharacter.SingleQuote,
   "%": VestaboardCharacter.PercentSign,
   ",": VestaboardCharacter.Comma,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the "‚" character, which will now be recognized as a single quote on the Vestaboard.
- **Chores**
  - Updated the package version to 1.2.17.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->